### PR TITLE
Kill `bspc` at startup

### DIFF
--- a/files/bspwmrc
+++ b/files/bspwmrc
@@ -113,7 +113,7 @@ bspc rule -a stalonetray state=floating manage=off
 ## Autostart -------------------------------------------------#
 
 # Kill if already running
-killall -9 xsettingsd sxhkd dunst ksuperkey xfce4-power-manager
+killall -9 xsettingsd sxhkd dunst ksuperkey xfce4-power-manager bspc
 
 # Lauch xsettingsd daemon
 xsettingsd &


### PR DESCRIPTION
Reason: currently, every restart of bspwm (ctrl+shift+r) leaves 2 processes running: `bash bspfloat` and `bspc`. Frequent restarts can spam the process tree. Killing `bspc` at startup solves the issue.

<details>

![image](https://user-images.githubusercontent.com/64320078/162395431-6dae02ca-f742-4726-be53-52cac45d5a1f.png)
</details>
